### PR TITLE
Drop support for Django<3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.6
-        - 3.7
         - 3.8
         - 3.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    Django>=2.2
+    Django>=3.2
     feincms3>=0.91.0
     html-sanitizer
     django-translated-fields>=0.10.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31,32}
-    py{38,39}-dj{main}
+    py{38,39}-dj{32,main}
     style
 
 [testenv]
@@ -11,9 +10,6 @@ commands =
     python -Wd {envbindir}/coverage run tests/manage.py test -v2 --keepdb {posargs:testapp}
     coverage report -m
 deps =
-    dj22: Django>=2.2,<3.0
-    dj30: Django>=3.0,<3.1
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<4.0
     djmain: https://github.com/django/django/archive/main.tar.gz
 


### PR DESCRIPTION
We can take advantage of the AppConfig autodiscovery like this.